### PR TITLE
comment margin-bottom edited

### DIFF
--- a/src/pages/detailedpage.jsx
+++ b/src/pages/detailedpage.jsx
@@ -230,6 +230,7 @@ const CommentsWrapper = styled.div`
 display: flex;
 flex-direction: row;
 gap: 10px;
+margin-bottom: 10px;
 
 h5 {
   margin-left: 30px;


### PR DESCRIPTION
댓글이 없으면 댓글창이 잘리는 현상 해결 - 댓글 밑 마진 조절했습니다.